### PR TITLE
Add endpoint to rediscover devices

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ def get_device(device_name):
     if found_device == None:
         return Response(json.dumps({"error": "no device found"}), status=404, mimetype='application/json')
     else:
-        device = format_device(found_device, ip_address)
+        device = format_device(found_device, ip_address, True)
 
         headers = {'Access-Control-Allow-Origin': '*'}
         return Response(json.dumps(device), status=200, mimetype='application/json', headers=headers)
@@ -149,9 +149,9 @@ def turn_off_device(device_name):
 
 
 # Helper functions
-def format_device(device, ip_address):
+def format_device(device, ip_address, include_device_sys_info=False):
     url_formatted_device_name = device.alias.replace(' ', '%20')
-    device = {
+    formatted_device = {
         "name": device.alias, 
         "ip_address": ip_address, 
         "is_on": device.is_on,
@@ -163,7 +163,10 @@ def format_device(device, ip_address):
         }
     }
 
-    return device
+    if (include_device_sys_info):
+        formatted_device = {**formatted_device, "system_info": device.sys_info}
+
+    return formatted_device
 
 def format_device_power_state_response(response):
     headers = {'Access-Control-Allow-Origin': '*'}

--- a/kasa_device_manager.py
+++ b/kasa_device_manager.py
@@ -61,6 +61,9 @@ class KasaDeviceManager:
 
         return devices
 
+    def rediscover_devices(self):
+        self.devices = self._discover_devices()
+
     def get_device(self, device_name):
         # Find the device and return the most current state of it
         for ip_address, smart_device in self.devices.items():


### PR DESCRIPTION
Release notes:
Adds a new endpoint `/devices/rediscover` to trigger the server to rediscover devices on the network